### PR TITLE
Fixed path to Utils folder

### DIFF
--- a/packages/hsl-shared-components/src/utils.js
+++ b/packages/hsl-shared-components/src/utils.js
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { Platform } from 'react-primitives';
 import { rem } from 'polished';
 
-import { Desktop, Mobile, WindowSize } from './Utils';
+import { Desktop, Mobile, WindowSize } from './Utils/';
 
 export { Desktop, Mobile, WindowSize };
 


### PR DESCRIPTION
Fixed folder path to avoid CaseSensitivePathsPlugin related errors on some file systems.