### PR TITLE
Build command for hsl-packages without watch

### DIFF
--- a/packages/hsl-shared-components/package.json
+++ b/packages/hsl-shared-components/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "prepublish": "babel src/ --out-dir lib/ --ignore .test.js",
     "build:watch": "babel src/ --out-dir lib/ --watch --ignore .test.js",
-    "build": "babel src/ --out-dir lib/",
+    "build": "yarn prepublish",
     "test": "jest",
     "es-lint": "eslint ."
   },

--- a/packages/hsl-shared-components/package.json
+++ b/packages/hsl-shared-components/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "prepublish": "babel src/ --out-dir lib/ --ignore .test.js",
     "build:watch": "babel src/ --out-dir lib/ --watch --ignore .test.js",
+    "build": "babel src/ --out-dir lib/",
     "test": "jest",
     "es-lint": "eslint ."
   },


### PR DESCRIPTION
Don't force people running local storybook to have built files on watch